### PR TITLE
修改了5.1.5小节bean作用域的描述

### DIFF
--- a/docs/e-1spring.md
+++ b/docs/e-1spring.md
@@ -119,11 +119,13 @@ AOP(Aspect-Oriented Programming:面向切面编程)能够将那些与业务无�
 
 #### Spring 中的 bean 的作用域有哪些?
 
-- singleton : 唯一 bean 实例，Spring 中的 bean 默认都是单例的。
-- prototype : 每次请求都会创建一个新的 bean 实例。
+- singleton : 在spring IoC容器仅存在一个Bean实例，Bean以单例方式存在，默认值。
+- prototype : 每次从容器中调用Bean时，都返回一个新的实例，即每次调用getBean()时，相当于执行newXxxBean()。
 - request : 每一次HTTP请求都会产生一个新的bean，该bean仅在当前HTTP request内有效。
-- session : 每一次HTTP请求都会产生一个新的 bean，该bean仅在当前 HTTP session 内有效。
+- session : 同一个HTTP Session共享一个Bean，不同Session使用不同的Bean。
 - global-session： 全局session作用域，仅仅在基于portlet的web应用中才有意义，Spring5已经没有了。Portlet是能够生成语义代码(例如：HTML)片段的小型Java Web插件。它们基于portlet容器，可以像servlet一样处理HTTP请求。但是，与 servlet 不同，每个 portlet 都有不同的会话
+
+参考自[W3Cschool-bean作用域](https://www.w3cschool.cn/wkspring/nukv1ice.html)
 
 #### Spring 中的单例 bean 的线程安全问题了解吗？
 


### PR DESCRIPTION
我是一个即将参加校招的非科班生，今天读完了Guide哥的面试突击版，非常感谢Guide哥的总结，从这里也学到了很多。看到5.1.4小节的Spring 中的 bean 的作用域的时候看到有些描述不是很能理解，在网上查了一些资料以后，在这里提出，希望能有所帮助。

# 原文

#### 5.1.5 Spring 中的 bean 的作用域有哪些?

- singleton : 唯一 bean 实例，Spring 中的 bean 默认都是单例的。
- prototype : 每次请求都会创建一个新的 bean 实例。
- request : 每一次HTTP请求都会产生一个新的bean，该bean仅在当前HTTP request内有效。
- session : 每一次HTTP请求都会产生一个新的 bean，该bean仅在当前 HTTP session 内有效。
- global-session： 全局session作用域，仅仅在基于portlet的web应用中才有意义，Spring5已经没有了。Portlet是能够生成语义代码(例如：HTML)片段的小型Java Web插件。它们基于portlet容器，可以像servlet一样处理HTTP请求。但是，与 servlet 不同，每个 portlet 都有不同的会话

# 这里的表述有两个地方不太好理解

## 1 prototype的作用范围

在《JavaGuide面试突击版》中，prototype的作用范围的描述是`每次请求都会创建一个新的 bean 实例`。感觉原文的表述不太清楚，似乎是想说每次HTTP请求都会创建一个bean实例。（当然也可能是我理解有误会）

在Spring5.2.5官方文档中的描述是`Scopes a single bean definition to any number of object instances.`。官方文档的说法也不清楚。

W3Cschool里的描述是`每次从容器中调用Bean时，都返回一个新的实例，即每次调用getBean()时，相当于执行newXxxBean()`。我觉得这个描述是比较清晰并且容易理解的。

## 2 session的作用范围

原文描述是`每一次HTTP请求都会产生一个新的 bean，该bean仅在当前 HTTP session 内有效`，这应该是不对的，session的作用范围是在同一个session中共享一个bean实例，不同的session中使用不同的bean实例。而在同一个session里可以发起多个http请求，所以原文的描述`每一次HTTP请求都会产生一个新的 bean`显然是不对的。

# 修改建议

可以参考[W3Cschool](https://www.w3cschool.cn/wkspring/nukv1ice.html)里的描述

- prototype：每次从容器中调用Bean时，都返回一个新的实例，即每次调用getBean()时，相当于执行newXxxBean()
- session：同一个HTTP Session共享一个Bean，不同Session使用不同的Bean，仅适用于WebApplicationContext环境