### PR TITLE
synchronized关键字代码示例 语法错误修复

### DIFF
--- a/docs/b-3Java多线程.md
+++ b/docs/b-3Java多线程.md
@@ -304,7 +304,7 @@ synchronized void method() {
 **2.修饰静态方法:** 也就是给当前类加锁，会作用于类的所有对象实例 ，进入同步代码前要获得 **当前 class 的锁**。因为静态成员不属于任何一个实例对象，是类成员（ _static 表明这是该类的一个静态资源，不管 new 了多少个对象，只有一份_）。所以，如果一个线程 A 调用一个实例对象的非静态 `synchronized` 方法，而线程 B 需要调用这个实例对象所属类的静态 `synchronized` 方法，是允许的，不会发生互斥现象，**因为访问静态 `synchronized` 方法占用的锁是当前类的锁，而访问非静态 `synchronized` 方法占用的锁是当前实例对象锁**。
 
 ```java
-synchronized void staic method() {
+synchronized staic void method() {
   //业务代码
 }
 ```


### PR DESCRIPTION
另外下图这里不知道是作者笔误，还是我没有理解哈，对类加锁为什么会作用于类的所有对象实例呢？烦请作者解答下
![图片](https://user-images.githubusercontent.com/33870926/111476066-bbada500-8768-11eb-95c3-7e0ba3380412.png)
